### PR TITLE
Improve tacmap and dropship map rendering when handling multiz maps

### DIFF
--- a/code/game/machinery/computer/dropship_weapons.dm
+++ b/code/game/machinery/computer/dropship_weapons.dm
@@ -27,6 +27,7 @@
 	// groundside maps
 	var/datum/tacmap/tacmap
 	var/minimap_type = MINIMAP_FLAG_USCM
+	var/current_zlevel = 1
 
 	// Cameras
 	var/camera_target_id
@@ -180,7 +181,13 @@
 		map_refs += map_holder?.map_ref
 	.["tactical_map_ref"] = map_refs
 	.["camera_map_ref"] = camera_map_name
-	.["zlevel"] = 0
+
+	if(length(tacmap.map_holders) <= 1)
+		.["zlevel"] = 0     // Single-level maps start at zlevel 0
+		current_zlevel = 0
+	else
+		.["zlevel"] = 1     // Multi-level maps start at zlevel 1
+		current_zlevel = 1
 	.["zlevelMax"] = length(map_refs)
 
 /obj/structure/machinery/computer/dropship_weapons/ui_data(mob/user)
@@ -270,6 +277,15 @@
 		if("select_equipment")
 			var/base_tag = params["equipment_id"]
 			ui_equip_interact(user, base_tag)
+			return TRUE
+
+		if("change_zlevel")
+			var/new_zlevel = params["zlevel"]
+			// Handle boundary checking for both single-level and multi-level maps
+			var/min_zlevel = length(tacmap.map_holders) <= 1 ? 0 : 1
+			var/max_zlevel = length(tacmap.map_holders) <= 1 ? 0 : length(tacmap.map_holders)
+			if(new_zlevel >= min_zlevel && new_zlevel <= max_zlevel)
+				current_zlevel = new_zlevel
 			return TRUE
 
 		if("start_watching")

--- a/tgui/packages/tgui/interfaces/DropshipWeaponsConsole.tsx
+++ b/tgui/packages/tgui/interfaces/DropshipWeaponsConsole.tsx
@@ -21,7 +21,7 @@ export interface DropshipProps {
   fulton_targets: Array<string>;
   selected_eqp: number;
   tactical_map_ref?: Array<string>;
-  zlevel: number;
+  zlevel?: number;
   zlevelMax: number;
   camera_map_ref?: string;
   camera_target_id?: string;
@@ -278,8 +278,12 @@ const WeaponsMfdPanel = (props) => {
 };
 
 const BaseMfdPanel = (props: MfdProps) => {
+  const { data } = useBackend<DropshipProps>();
   const { setPanelState } = mfdState(props.panelStateId);
   const { otherPanelState } = otherMfdState(props.otherPanelStateId);
+
+  // Set default zlevel to 2 if not provided (this map starts at zlevel 2)
+  const zlevel = data.zlevel ?? 2;
 
   return (
     <MfdPanel
@@ -322,6 +326,12 @@ const BaseMfdPanel = (props: MfdProps) => {
 
 const PrimaryPanel = (props: MfdProps) => {
   const { panelState } = mfdState(props.panelStateId);
+  const { data } = useBackend<DropshipProps>();
+
+  // Use zlevel as part of the key to force re-render when it changes
+  // Backend uses 1-indexed zlevels, this map starts at zlevel 2
+  const zlevel = data.zlevel ?? 2;
+
   switch (panelState) {
     case 'camera':
       return <CameraMfdPanel {...props} />;

--- a/tgui/packages/tgui/interfaces/MfdPanels/MapPanel.tsx
+++ b/tgui/packages/tgui/interfaces/MfdPanels/MapPanel.tsx
@@ -1,6 +1,5 @@
 import { useBackend } from 'tgui/backend';
-import { Box } from 'tgui/components';
-import { ByondUi } from 'tgui/components';
+import { Box, ByondUi } from 'tgui/components';
 
 import { MfdPanel, type MfdProps } from './MultifunctionDisplay';
 import { mfdState } from './stateManagers';
@@ -8,24 +7,34 @@ import type { MapProps } from './types';
 
 export const MapMfdPanel = (props: MfdProps) => {
   const { setPanelState } = mfdState(props.panelStateId);
-  const { data } = useBackend<MapProps>();
+  const { data, act } = useBackend<MapProps>();
+
+  // Backend provides zlevel: 0 for single-level maps, 2 for multi-level maps
+  const zlevel = data.zlevel ?? 0;
 
   const rightButtons =
     data.zlevelMax > 1
       ? [
           {
-            children: '⬆',
+            children: '+ Up',
             onClick: () => {
-              if (data.zlevel + 1 < data.zlevelMax) {
-                data.zlevel++;
+              if (zlevel < data.zlevelMax) {
+                // Update frontend data immediately so the key changes
+                data.zlevel = zlevel + 1;
+                act('change_zlevel', { zlevel: zlevel + 1 });
               }
             },
           },
           {
-            children: '⬇',
+            children: '- Down',
             onClick: () => {
-              if (data.zlevel - 1 >= 0) {
-                data.zlevel--;
+              // For single-level maps (zlevel 0), don't allow going down
+              // For multi-level maps, minimum is zlevel 1
+              const minZlevel = data.zlevelMax <= 1 ? 0 : 1;
+              if (zlevel > minZlevel) {
+                // Update frontend data immediately so the key changes
+                data.zlevel = zlevel - 1;
+                act('change_zlevel', { zlevel: zlevel - 1 });
               }
             },
           },
@@ -43,20 +52,54 @@ export const MapMfdPanel = (props: MfdProps) => {
       ]}
       rightButtons={rightButtons}
     >
-      <MapPanel />
+      <MapPanel zlevel={zlevel} mapRefs={data.tactical_map_ref} />
     </MfdPanel>
   );
 };
 
-const MapPanel = () => {
-  const { data } = useBackend<MapProps>();
+const MapPanel = (props: {
+  readonly zlevel?: number;
+  readonly mapRefs?: string[];
+}) => {
+  // Use the zlevel from props (backend provides correct value), fallback to 0 for safety
+  const zlevel = props.zlevel ?? 0;
+  const mapRefs = props.mapRefs ?? [];
+
+  // For single-level maps: zlevel 0 maps to index 0
+  // For multi-level maps: zlevel 1+ maps to index (zlevel-1)
+  // But we need to determine if this is single or multi-level
+  const isSingleLevel = mapRefs.length <= 1;
+  const mapIndex = isSingleLevel ? 0 : zlevel - 1;
+
+  // Don't render if we don't have map data
+  if (!mapRefs || mapRefs.length === 0) {
+    return (
+      <Box className="NavigationMenu">
+        <div>No map references available</div>
+      </Box>
+    );
+  }
+
+  // Check if the calculated index is valid
+  if (mapIndex < 0 || mapIndex >= mapRefs.length || !mapRefs[mapIndex]) {
+    return (
+      <Box className="NavigationMenu">
+        <div>
+          Invalid map index: zlevel {zlevel} (index {mapIndex}) - Available: 0
+          to {mapRefs.length - 1}
+        </div>
+      </Box>
+    );
+  }
+
   return (
     <Box className="NavigationMenu">
       <ByondUi
-        key={data.zlevel}
+        key={`map_${zlevel}_${mapRefs[mapIndex]}`}
         params={{
-          id: data.tactical_map_ref[data.zlevel],
+          id: mapRefs[mapIndex],
           type: 'map',
+          'background-color': 'none',
         }}
         className="MapPanel"
       />


### PR DESCRIPTION
- Fixed bug with changing levels not rerending map (previous behaviour forced the user to have to close and open the tacmap to rerender)
- Dropship map now displays properly for multiz enabled maps and allowes changing of zlevel

:cl: rattybag

fix: multiz tactical and dropship map initial rendering and rerendering
ui: tactical and dropship map initial rendering and rerendering
/:cl:

